### PR TITLE
Modify gomega configmap assertion docstring

### DIFF
--- a/pkg/gomega/assertions/eventually_configmap.go
+++ b/pkg/gomega/assertions/eventually_configmap.go
@@ -10,7 +10,6 @@ import (
 
 // EventuallyConfigMap is a gomega async assertion that can be used with the
 // standard or custom gomega matchers
-// Polls the resource every 30 seconds until success or timeout defined by POLLING_TIMEOUT
 //
 //	EventuallyConfigMap(ctx, client, configMapName, namespace).Should(Not(BeNil()), "config map %s should exist", configMapName)
 func EventuallyConfigMap(ctx context.Context, client *openshift.Client, name, namespace string) gomega.AsyncAssertion {

--- a/pkg/gomega/assertions/eventually_configmap.go
+++ b/pkg/gomega/assertions/eventually_configmap.go
@@ -11,7 +11,7 @@ import (
 // EventuallyConfigMap is a gomega async assertion that can be used with the
 // standard or custom gomega matchers
 //
-//	EventuallyConfigMap(ctx, client, configMapName, namespace).Should(Not(BeNil()), "config map %s should exist", configMapName)
+//	EventuallyConfigMap(ctx, client, configMapName, namespace).ShouldNot(BeNil()), "config map %s should exist", configMapName)
 func EventuallyConfigMap(ctx context.Context, client *openshift.Client, name, namespace string) gomega.AsyncAssertion {
 	return gomega.Eventually(ctx, func(ctx context.Context) (*corev1.ConfigMap, error) {
 		var configMap corev1.ConfigMap


### PR DESCRIPTION
Removes the statement mentioning polling until success as its not implemented by the assertion.