### PR TITLE
pkg/clients/openshift: implement impersonation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/common v0.43.0
 	k8s.io/api v0.27.2
 	k8s.io/apimachinery v0.27.2
+	k8s.io/client-go v0.27.2
 	sigs.k8s.io/e2e-framework v0.2.0
 )
 
@@ -63,7 +64,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/client-go v0.27.2 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect

--- a/pkg/clients/openshift/client.go
+++ b/pkg/clients/openshift/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/api"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/e2e-framework/klient/conf"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 )
@@ -29,4 +30,30 @@ func NewFromKubeconfig(filename string) (*Client, error) {
 		return nil, fmt.Errorf("unable to register openshift api schemes: %w", err)
 	}
 	return &Client{client}, nil
+}
+
+// Impersonate returns a copy of the client with a new ImpersonationConfig
+// established on the underlying client, acting as the provided user
+//
+//	backplaneUser, _ := oc.Impersonate("test-user@redhat.com", "dedicated-admins")
+func (c *Client) Impersonate(user string, groups ...string) (*Client, error) {
+	if user != "" {
+		// these groups are required for impersonating a user
+		groups = append(groups, "system:authenticated", "system:authenticated:oauth")
+	}
+
+	client := *c
+	newRestConfig := rest.CopyConfig(c.Resources.GetConfig())
+	newRestConfig.Impersonate = rest.ImpersonationConfig{UserName: user, Groups: groups}
+	newResources, err := resources.New(newRestConfig)
+	if err != nil {
+		return nil, err
+	}
+	client.Resources = newResources
+
+	if err = api.Install(client.GetScheme()); err != nil {
+		return nil, fmt.Errorf("unable to register openshift api schemes: %w", err)
+	}
+
+	return &client, nil
 }


### PR DESCRIPTION
allows a client to impersonate another user/serviceaccount to test
permissions

Signed-off-by: Brady Pratt <bpratt@redhat.com>
