### PR TITLE
SDCICD-1043: Port missing ROSA create cluster options from osde2e

### DIFF
--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -29,6 +29,7 @@ type CreateClusterOptions struct {
 	ComputeMachineType string
 	MachineCidr        string
 	Mode               string
+	PodCIDR            string
 	Properties         string
 	ServiceCIDR        string
 	SubnetIDs          string
@@ -294,6 +295,10 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 		"--support-role-arn", options.accountRoles.supportRoleARN,
 		"--worker-iam-role", options.accountRoles.workerRoleARN,
 		"--yes",
+	}
+
+	if options.PodCIDR != "" {
+		commandArgs = append(commandArgs, "--pod-cidr", options.PodCIDR)
 	}
 
 	if options.ServiceCIDR != "" {

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -18,6 +18,7 @@ import (
 
 // CreateClusterOptions represents data used to create clusters
 type CreateClusterOptions struct {
+	FIPS     bool
 	HostedCP bool
 	STS      bool
 
@@ -306,6 +307,10 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 
 	if options.STS {
 		commandArgs = append(commandArgs, "--sts")
+	}
+
+	if options.FIPS {
+		commandArgs = append(commandArgs, "--fips")
 	}
 
 	r.log.Info("Initiating cluster creation", clusterNameLoggerKey, options.ClusterName, ocmEnvironmentLoggerKey, r.ocmEnvironment)

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -30,6 +30,7 @@ type CreateClusterOptions struct {
 	ComputeMachineType string
 	MachineCidr        string
 	Mode               string
+	NetworkType        string
 	PodCIDR            string
 	Properties         string
 	ServiceCIDR        string
@@ -323,6 +324,10 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 
 	if options.FIPS {
 		commandArgs = append(commandArgs, "--fips")
+	}
+
+	if options.NetworkType != "" && options.NetworkType != "OVNKubernetes" {
+		commandArgs = append(commandArgs, "--network-type", options.NetworkType)
 	}
 
 	r.log.Info("Initiating cluster creation", clusterNameLoggerKey, options.ClusterName, ocmEnvironmentLoggerKey, r.ocmEnvironment)

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -20,6 +20,7 @@ import (
 type CreateClusterOptions struct {
 	FIPS     bool
 	HostedCP bool
+	MultiAZ  bool
 	STS      bool
 
 	HostPrefix int
@@ -291,7 +292,6 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 		"--machine-cidr", options.MachineCidr,
 		"--region", r.awsCredentials.Region,
 		"--version", options.Version,
-		"--replicas", fmt.Sprint(options.Replicas),
 		"--host-prefix", fmt.Sprint(options.HostPrefix),
 		"--controlplane-iam-role", options.accountRoles.controlPlaneRoleARN,
 		"--role-arn", options.accountRoles.installerRoleARN,
@@ -329,6 +329,16 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 	if options.NetworkType != "" && options.NetworkType != "OVNKubernetes" {
 		commandArgs = append(commandArgs, "--network-type", options.NetworkType)
 	}
+
+	if options.MultiAZ {
+		commandArgs = append(commandArgs, "--multi-az")
+
+		if options.Replicas < 3 {
+			options.Replicas = 3
+		}
+	}
+
+	commandArgs = append(commandArgs, "--replicas", fmt.Sprint(options.Replicas))
 
 	r.log.Info("Initiating cluster creation", clusterNameLoggerKey, options.ClusterName, ocmEnvironmentLoggerKey, r.ocmEnvironment)
 

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -26,18 +26,21 @@ type CreateClusterOptions struct {
 	HostPrefix int
 	Replicas   int
 
-	ChannelGroup       string
-	ClusterName        string
-	ComputeMachineType string
-	MachineCidr        string
-	Mode               string
-	NetworkType        string
-	PodCIDR            string
-	Properties         string
-	ServiceCIDR        string
-	SubnetIDs          string
-	Version            string
-	WorkingDir         string
+	AdditionalTrustBundleFile string
+	ChannelGroup              string
+	ClusterName               string
+	ComputeMachineType        string
+	HTTPProxy                 string
+	HTTPSProxy                string
+	MachineCidr               string
+	Mode                      string
+	NetworkType               string
+	PodCIDR                   string
+	Properties                string
+	ServiceCIDR               string
+	SubnetIDs                 string
+	Version                   string
+	WorkingDir                string
 
 	oidcConfigID string
 
@@ -339,6 +342,22 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 	}
 
 	commandArgs = append(commandArgs, "--replicas", fmt.Sprint(options.Replicas))
+
+	if options.SubnetIDs != "" {
+		commandArgs = append(commandArgs, "--subnet-ids", options.SubnetIDs)
+
+		if options.HTTPProxy != "" {
+			commandArgs = append(commandArgs, "--http-proxy", options.HTTPProxy)
+		}
+
+		if options.HTTPSProxy != "" {
+			commandArgs = append(commandArgs, "--https-proxy", options.HTTPSProxy)
+		}
+
+		if options.AdditionalTrustBundleFile != "" {
+			commandArgs = append(commandArgs, "----additional-trust-bundle-file", options.AdditionalTrustBundleFile)
+		}
+	}
 
 	r.log.Info("Initiating cluster creation", clusterNameLoggerKey, options.ClusterName, ocmEnvironmentLoggerKey, r.ocmEnvironment)
 

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -48,6 +48,7 @@ type CreateClusterOptions struct {
 
 	InstallTimeout     time.Duration
 	HealthCheckTimeout time.Duration
+	ExpirationDuration time.Duration
 }
 
 // DeleteClusterOptions represents data used to delete clusters
@@ -357,6 +358,10 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 		if options.AdditionalTrustBundleFile != "" {
 			commandArgs = append(commandArgs, "----additional-trust-bundle-file", options.AdditionalTrustBundleFile)
 		}
+	}
+
+	if options.ExpirationDuration > 0 {
+		commandArgs = append(commandArgs, "--expiration-time", time.Now().Add(options.ExpirationDuration*time.Minute).UTC().Format(time.RFC3339))
 	}
 
 	r.log.Info("Initiating cluster creation", clusterNameLoggerKey, options.ClusterName, ocmEnvironmentLoggerKey, r.ocmEnvironment)

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -22,7 +22,8 @@ type CreateClusterOptions struct {
 	HostedCP bool
 	STS      bool
 
-	Replicas int
+	HostPrefix int
+	Replicas   int
 
 	ChannelGroup       string
 	ClusterName        string
@@ -290,6 +291,7 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 		"--region", r.awsCredentials.Region,
 		"--version", options.Version,
 		"--replicas", fmt.Sprint(options.Replicas),
+		"--host-prefix", fmt.Sprint(options.HostPrefix),
 		"--controlplane-iam-role", options.accountRoles.controlPlaneRoleARN,
 		"--role-arn", options.accountRoles.installerRoleARN,
 		"--support-role-arn", options.accountRoles.supportRoleARN,

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -30,6 +30,7 @@ type CreateClusterOptions struct {
 	MachineCidr        string
 	Mode               string
 	Properties         string
+	ServiceCIDR        string
 	SubnetIDs          string
 	Version            string
 	WorkingDir         string
@@ -293,6 +294,10 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 		"--support-role-arn", options.accountRoles.supportRoleARN,
 		"--worker-iam-role", options.accountRoles.workerRoleARN,
 		"--yes",
+	}
+
+	if options.ServiceCIDR != "" {
+		commandArgs = append(commandArgs, "--service-cidr", options.ServiceCIDR)
 	}
 
 	if options.Properties != "" {


### PR DESCRIPTION
# What
This PR ports the additional ROSA create cluster options that the existing ROSA provider supports within osde2e.

# Jira
- [SDCICD-1043](https://issues.redhat.com/browse/SDCICD-1043)
