### PR TITLE
ROSA provider: perform a region check prior to cluster creation

### DIFF
--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -83,6 +83,11 @@ func (r *Provider) CreateCluster(ctx context.Context, options *CreateClusterOpti
 
 	options.setDefaultCreateClusterOptions()
 
+	err := r.regionCheck(ctx, r.awsCredentials.Region, options.HostedCP, options.MultiAZ)
+	if err != nil {
+		return "", &clusterError{action: action, err: err}
+	}
+
 	if options.STS {
 		version, err := semver.NewVersion(options.Version)
 		if err != nil {

--- a/pkg/openshift/rosa/regions.go
+++ b/pkg/openshift/rosa/regions.go
@@ -1,0 +1,83 @@
+package rosa
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+
+	"github.com/openshift/osde2e-common/internal/cmd"
+)
+
+// regionError represents the custom error
+type regionError struct {
+	err error
+}
+
+// Error returns the formatted error message when regionError is invoked
+func (r *regionError) Error() string {
+	return fmt.Sprintf("region check failed: %v", r.err)
+}
+
+// regionCheck verifies the region provided supports either hosted control plane clusters
+// or multi az clusters based on the cluster creation options
+func (r *Provider) regionCheck(ctx context.Context, regionName string, hostedCP, multiAZ bool) error {
+	var (
+		err     error
+		enabled bool
+
+		regionFound = false
+	)
+
+	commandArgs := []string{
+		"list", "regions",
+		"--output", "json",
+	}
+
+	if hostedCP {
+		commandArgs = append(commandArgs, "--hosted-cp")
+	}
+
+	if multiAZ {
+		commandArgs = append(commandArgs, "--multi-az")
+	}
+
+	r.log.Info("Performing ROSA AWS region check", "region", regionName, "hostedCP", hostedCP, "multiAZ", multiAZ)
+
+	stdout, stderr, err := r.RunCommand(ctx, exec.CommandContext(ctx, r.rosaBinary, commandArgs...))
+	if err != nil {
+		return &regionError{fmt.Errorf("error: %v, stderr: %v", err, stderr)}
+	}
+
+	availableRegions, err := cmd.ConvertOutputToListOfMaps(stdout)
+	if err != nil {
+		return &regionError{err: fmt.Errorf("failed to convert output to list of maps: %v", err)}
+	}
+
+	for _, region := range availableRegions {
+		if enabled, err = strconv.ParseBool(fmt.Sprint(region["enabled"])); err != nil {
+			return &regionError{fmt.Errorf("failed to convert region %q 'enabled' string key to boolean value", regionName)}
+		}
+
+		if fmt.Sprint(region["id"]) != regionName {
+			continue
+		}
+
+		regionFound = true
+
+		if !enabled {
+			return &regionError{fmt.Errorf("region %q is not enabled", regionName)}
+		}
+
+		break
+	}
+
+	if !regionFound {
+		return &regionError{fmt.Errorf("region %q is not enabled/valid for the aws account in use and "+
+			"supports: hostedCP=%t, multiAZ=%t", regionName, hostedCP, multiAZ)}
+	}
+
+	r.log.Info("ROSA AWS region check passed", "region", regionName, "hostedCP", hostedCP, "multiAZ", multiAZ)
+
+	return nil
+}


### PR DESCRIPTION
# What
Region check will tell the caller function that the region they supplied either does not support hosted control plane clusters or multi az clusters. Providing the caller function with information up front over performing additional steps prior to initiating cluster creation.

# Jira
- [SDCICD-1043](https://issues.redhat.com//browse/SDCICD-1043)