### PR TITLE
ROSA provider: support getting versions

### DIFF
--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -103,8 +103,6 @@ func (r *Provider) CreateCluster(ctx context.Context, options *CreateClusterOpti
 	}
 
 	if options.HostedCP {
-		// TODO: region check for hcp support
-
 		oidcConfigID, err := r.createOIDCConfig(
 			ctx,
 			options.ClusterName,

--- a/pkg/openshift/rosa/versions.go
+++ b/pkg/openshift/rosa/versions.go
@@ -1,0 +1,82 @@
+package rosa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/openshift/osde2e-common/internal/cmd"
+)
+
+// versionError represents the custom error
+type versionError struct {
+	action string
+	err    error
+}
+
+// Error returns the formatted error message when versionError is invoked
+func (v *versionError) Error() string {
+	return fmt.Sprintf("%s versions failed: %s", v.action, v.err)
+}
+
+// version represents a rosa version object
+type version struct {
+	ID                        string    `json:"id"`
+	Href                      string    `json:"href"`
+	AvailableUpgrades         []string  `json:"available_upgrades"`
+	ChannelGroup              string    `json:"channel_group"`
+	EndOfLifeTimestamp        time.Time `json:"end_of_life_timestamp"`
+	RawID                     string    `json:"raw_id"`
+	ReleaseImage              string    `json:"release_image"`
+	RosaEnabled               bool      `json:"rosa_enabled"`
+	Default                   bool      `json:"default"`
+	Enabled                   bool      `json:"enabled"`
+	HostedControlPlaneEnabled bool      `json:"hosted_control_plane_enabled"`
+}
+
+// Versions returns the rosa versions for the supported channel and additional options provided
+func (r *Provider) Versions(ctx context.Context, channelGroup string, hostedCP bool) ([]*version, error) {
+	const action = "get"
+
+	commandArgs := []string{
+		"list", "versions",
+		"--channel-group", channelGroup,
+		"--output", "json",
+	}
+
+	if hostedCP {
+		commandArgs = append(commandArgs, "--hosted-cp")
+	}
+
+	r.log.Info("Getting rosa versions", clusterChannelGroupLoggerKey, channelGroup,
+		"hostedCP", hostedCP, ocmEnvironmentLoggerKey, r.ocmEnvironment)
+
+	stdout, stderr, err := r.RunCommand(ctx, exec.CommandContext(ctx, r.rosaBinary, commandArgs...))
+	if err != nil {
+		return nil, &versionError{action: action, err: fmt.Errorf("error: %v, stderr: %v", err, stderr)}
+	}
+
+	availableVersions, err := cmd.ConvertOutputToListOfMaps(stdout)
+	if err != nil {
+		return nil, &versionError{action: action, err: fmt.Errorf("failed to convert output to list of maps: %v", err)}
+	}
+
+	var versions []*version
+
+	availableVersionsBytes, err := json.Marshal(availableVersions)
+	if err != nil {
+		return nil, &versionError{action: action, err: fmt.Errorf("failed to marshal version data: %v", err)}
+	}
+
+	err = json.Unmarshal(availableVersionsBytes, &versions)
+	if err != nil {
+		return nil, &versionError{action: action, err: fmt.Errorf("failed to unmarshal version data: %v", err)}
+	}
+
+	r.log.Info("ROSA versions retrieved!", clusterChannelGroupLoggerKey, channelGroup,
+		"hostedCP", hostedCP, ocmEnvironmentLoggerKey, r.ocmEnvironment)
+
+	return versions, nil
+}


### PR DESCRIPTION
# What

This PR adds a new method named `Versions` that can be called to return back a list of available versions to deploy clusters with based on the provided options (channel group and hosted control plane support).

# Jira
- [SDCICD-1043](https://issues.redhat.com//browse/SDCICD-1043)