### PR TITLE
ROSA provider: add support for randomly selecting AWS region to use

### DIFF
--- a/pkg/clouds/aws/credentials.go
+++ b/pkg/clouds/aws/credentials.go
@@ -64,11 +64,15 @@ func (c *AWSCredentials) CredentialsAsList() []string {
 
 	switch priorityLevel {
 	case 0:
-		return []string{fmt.Sprintf("AWS_PROFILE=%s", c.Profile)}
+		return []string{
+			fmt.Sprintf("AWS_PROFILE=%s", c.Profile),
+			fmt.Sprintf("AWS_REGION=%s", c.Region),
+		}
 	case 1:
 		return []string{
 			fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", c.AccessKeyID),
 			fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", c.SecretAccessKey),
+			fmt.Sprintf("AWS_REGION=%s", c.Region),
 		}
 	default:
 		return []string{}
@@ -81,11 +85,15 @@ func (c *AWSCredentials) CredentialsAsMap() map[string]string {
 
 	switch priorityLevel {
 	case 0:
-		return map[string]string{"AWS_PROFILE": c.Profile}
+		return map[string]string{
+			"AWS_PROFILE": c.Profile,
+			"AWS_REGION":  c.Region,
+		}
 	case 1:
 		return map[string]string{
 			"AWS_ACCESS_KEY_ID":     c.AccessKeyID,
 			"AWS_SECRET_ACCESS_KEY": c.SecretAccessKey,
+			"AWS_REGION":            c.Region,
 		}
 	default:
 		return map[string]string{}

--- a/pkg/openshift/rosa/regions.go
+++ b/pkg/openshift/rosa/regions.go
@@ -2,9 +2,11 @@ package rosa
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"math/rand"
 	"os/exec"
-	"strconv"
 
 	"github.com/openshift/osde2e-common/internal/cmd"
 )
@@ -19,53 +21,44 @@ func (r *regionError) Error() string {
 	return fmt.Sprintf("region check failed: %v", r.err)
 }
 
+// region represents a rosa aws region object
+type region struct {
+	ID                 string        `json:"id"`
+	Href               string        `json:"href"`
+	CCSOnly            bool          `json:"ccs_only"`
+	CloudProvider      cloudProvider `json:"cloud_provider"`
+	DisplayName        string        `json:"display_name"`
+	Enabled            bool          `json:"enabled"`
+	SupportsHyperShift bool          `json:"supports_hypershift"`
+	SupportsMultiAZ    bool          `json:"supports_multi_az"`
+}
+
+// cloudProvider represents a rosa aws region cloud provider object
+type cloudProvider struct {
+	ID   string `json:"id"`
+	Href string `json:"href"`
+}
+
 // regionCheck verifies the region provided supports either hosted control plane clusters
 // or multi az clusters based on the cluster creation options
 func (r *Provider) regionCheck(ctx context.Context, regionName string, hostedCP, multiAZ bool) error {
-	var (
-		err     error
-		enabled bool
+	regionFound := false
 
-		regionFound = false
-	)
-
-	commandArgs := []string{
-		"list", "regions",
-		"--output", "json",
-	}
-
-	if hostedCP {
-		commandArgs = append(commandArgs, "--hosted-cp")
-	}
-
-	if multiAZ {
-		commandArgs = append(commandArgs, "--multi-az")
+	regions, err := r.regions(ctx, hostedCP, multiAZ)
+	if err != nil {
+		return &regionError{err}
 	}
 
 	r.log.Info("Performing ROSA AWS region check", "region", regionName, "hostedCP", hostedCP, "multiAZ", multiAZ)
 
-	stdout, stderr, err := r.RunCommand(ctx, exec.CommandContext(ctx, r.rosaBinary, commandArgs...))
-	if err != nil {
-		return &regionError{fmt.Errorf("error: %v, stderr: %v", err, stderr)}
-	}
-
-	availableRegions, err := cmd.ConvertOutputToListOfMaps(stdout)
-	if err != nil {
-		return &regionError{err: fmt.Errorf("failed to convert output to list of maps: %v", err)}
-	}
-
-	for _, region := range availableRegions {
-		if enabled, err = strconv.ParseBool(fmt.Sprint(region["enabled"])); err != nil {
-			return &regionError{fmt.Errorf("failed to convert region %q 'enabled' string key to boolean value", regionName)}
-		}
-
-		if fmt.Sprint(region["id"]) != regionName {
+	for _, region := range regions {
+		if region.ID != regionName {
 			continue
 		}
 
 		regionFound = true
 
-		if !enabled {
+		if !region.Enabled {
 			return &regionError{fmt.Errorf("region %q is not enabled", regionName)}
 		}
 
@@ -80,4 +73,78 @@ func (r *Provider) regionCheck(ctx context.Context, regionName string, hostedCP,
 	r.log.Info("ROSA AWS region check passed", "region", regionName, "hostedCP", hostedCP, "multiAZ", multiAZ)
 
 	return nil
+}
+
+// selectRandomRegion selects a random enabled aws region to use
+func (r *Provider) selectRandomRegion(ctx context.Context) (string, error) {
+	r.log.Info("Selecting random aws region")
+
+	regions, err := r.regions(ctx, false, false)
+	if err != nil {
+		return "", err
+	}
+
+	var enabledRegions []string
+
+	for _, region := range regions {
+		if region.Enabled {
+			enabledRegions = append(enabledRegions, region.ID)
+		}
+	}
+
+	rand.Shuffle(len(enabledRegions), func(i, j int) {
+		enabledRegions[i], enabledRegions[j] = enabledRegions[j], enabledRegions[i]
+	})
+
+	if len(enabledRegions) == 0 {
+		return "", errors.New("no regions found")
+	}
+
+	selectedRegion := enabledRegions[0]
+
+	r.log.Info("Random aws region selected!", awsRegionLoggerKey, selectedRegion)
+
+	return selectedRegion, nil
+}
+
+// regions returns a list of available aws regions for the rh/aws account used
+func (r *Provider) regions(ctx context.Context, hostedCP, multiAZ bool) ([]*region, error) {
+	commandArgs := []string{
+		"list", "regions",
+		"--output", "json",
+	}
+
+	if hostedCP {
+		commandArgs = append(commandArgs, "--hosted-cp")
+	}
+
+	if multiAZ {
+		commandArgs = append(commandArgs, "--multi-az")
+	}
+
+	r.log.Info("Performing ROSA list regions", "hostedCP", hostedCP, "multiAZ", multiAZ)
+
+	stdout, stderr, err := r.RunCommand(ctx, exec.CommandContext(ctx, r.rosaBinary, commandArgs...))
+	if err != nil {
+		return nil, &regionError{fmt.Errorf("error: %v, stderr: %v", err, stderr)}
+	}
+
+	availableRegions, err := cmd.ConvertOutputToListOfMaps(stdout)
+	if err != nil {
+		return nil, &regionError{err: fmt.Errorf("failed to convert output to list of maps: %v", err)}
+	}
+
+	var regions []*region
+
+	availableRegionsBytes, err := json.Marshal(availableRegions)
+	if err != nil {
+		return nil, &regionError{err: fmt.Errorf("failed to marshal region data: %v", err)}
+	}
+
+	err = json.Unmarshal(availableRegionsBytes, &regions)
+	if err != nil {
+		return nil, &regionError{err: fmt.Errorf("failed to unmarshal region data: %v", err)}
+	}
+
+	return regions, nil
 }


### PR DESCRIPTION
# What
When a rosa provider object is constructed, if the region is an empty string or random is provided. A random region will be automatically assigned.

# Jira
- [SDCICD-1043](https://issues.redhat.com//browse/SDCICD-1043)