### PR TITLE
ROSA provider: add a field to turn on/off vpc deletion

### DIFF
--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -60,8 +60,9 @@ type DeleteClusterOptions struct {
 
 	oidcConfigID string
 
-	HostedCP bool
-	STS      bool
+	DeleteHostedCPVPC bool
+	HostedCP          bool
+	STS               bool
 
 	UninstallTimeout time.Duration
 }
@@ -198,14 +199,16 @@ func (r *Provider) DeleteCluster(ctx context.Context, options *DeleteClusterOpti
 			return &clusterError{action: action, err: err}
 		}
 
-		err = r.deleteHostedControlPlaneVPC(
-			ctx,
-			options.ClusterName,
-			r.awsCredentials.Region,
-			options.WorkingDir,
-		)
-		if err != nil {
-			return &clusterError{action: action, err: err}
+		if options.DeleteHostedCPVPC {
+			err = r.deleteHostedControlPlaneVPC(
+				ctx,
+				options.ClusterName,
+				r.awsCredentials.Region,
+				options.WorkingDir,
+			)
+			if err != nil {
+				return &clusterError{action: action, err: err}
+			}
 		}
 	}
 
@@ -538,6 +541,7 @@ func (o *CreateClusterOptions) setHealthCheckTimeout(duration time.Duration) {
 // setDefaultDeleteClusterOptions sets default options when creating clusters
 func (o *DeleteClusterOptions) setDefaultDeleteClusterOptions() {
 	if o.HostedCP {
+		o.DeleteHostedCPVPC = true
 		o.STS = true
 	}
 


### PR DESCRIPTION
# What
Previously when deleting a cluster and hosted control plane is enabled. It will always try to delete the aws vpc that was created. Since the create cluster allows the caller to supply subnet ids (by passing creating a vpc), we need to be able to skip deleting vpc when subnet ids are passed.

This commit introduces a new field to the delete cluster options struct. Allowing the caller to turn off vpc deletion. Caller will know if they provided subnet ids or had the vpc be created. Leaving the core method to act on the input.

# Jira
- [SDCICD-1043](https://issues.redhat.com//browse/SDCICD-1043)