### PR TITLE
ROSA provider: update HCP cluster health check to verify compute node count

### DIFF
--- a/pkg/clients/openshift/healthcheck.go
+++ b/pkg/clients/openshift/healthcheck.go
@@ -70,7 +70,7 @@ func (c *Client) OSDClusterHealthy(ctx context.Context, jobName, reportDir strin
 
 // HCPClusterHealthy waits for the cluster to be in a health "ready" state
 // by confirming nodes are available
-func (c *Client) HCPClusterHealthy(ctx context.Context, timeout time.Duration) error {
+func (c *Client) HCPClusterHealthy(ctx context.Context, computeNodes int, timeout time.Duration) error {
 	c.log.Info("Wait for hosted control plane cluster to healthy", timeoutLoggerKey, timeout)
 
 	err := wait.For(func() (bool, error) {
@@ -96,8 +96,7 @@ func (c *Client) HCPClusterHealthy(ctx context.Context, timeout time.Duration) e
 			}
 		}
 
-		// TODO: Compare with number of nodes cluster is deployed with
-		return true, nil
+		return len(nodes.Items) == computeNodes, nil
 	}, wait.WithTimeout(timeout))
 	if err != nil {
 		return fmt.Errorf("hosted control plane cluster health check failed: %v", err)

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -148,7 +148,14 @@ func (r *Provider) CreateCluster(ctx context.Context, options *CreateClusterOpti
 		return clusterID, &clusterError{action: action, err: err}
 	}
 
-	err = r.waitForClusterToBeHealthy(ctx, client, options.WorkingDir, options.HostedCP, options.HealthCheckTimeout)
+	err = r.waitForClusterToBeHealthy(
+		ctx,
+		client,
+		clusterID,
+		options.WorkingDir,
+		options.HostedCP,
+		options.HealthCheckTimeout,
+	)
 	if err != nil {
 		return clusterID, &clusterError{action: action, err: err}
 	}
@@ -476,9 +483,14 @@ func (r *Provider) waitForClusterToBeInstalled(ctx context.Context, clusterID, c
 }
 
 // waitForClusterToBeHealthy waits for the cluster health check job to succeed
-func (r *Provider) waitForClusterToBeHealthy(ctx context.Context, client *openshiftclient.Client, reportDir string, hostedCP bool, timeout time.Duration) error {
+func (r *Provider) waitForClusterToBeHealthy(ctx context.Context, client *openshiftclient.Client, clusterID, reportDir string, hostedCP bool, timeout time.Duration) error {
 	if hostedCP {
-		return client.HCPClusterHealthy(ctx, timeout)
+		cluster, err := r.findCluster(ctx, clusterID)
+		if err != nil {
+			return fmt.Errorf("hosted control plane cluster pre health check tasks failed, unable to locate cluster: %v", err)
+		}
+
+		return client.HCPClusterHealthy(ctx, cluster.Nodes().Compute(), timeout)
 	}
 	return client.OSDClusterHealthy(ctx, "osd-cluster-ready", reportDir, timeout)
 }


### PR DESCRIPTION
# What
This PR updates the ROSA hosted control plane cluster health checks to verify the number of compute nodes the cluster returns matches what is defined when the cluster was created.

# Jira
- [SDCICD-1043](https://issues.redhat.com//browse/SDCICD-1043)