### PR TITLE
ROSA provider: pass in cluster name to waitForClusterToBeHealthy over cluster ID

### DIFF
--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -154,7 +154,7 @@ func (r *Provider) CreateCluster(ctx context.Context, options *CreateClusterOpti
 		err = r.waitForClusterToBeHealthy(
 			ctx,
 			client,
-			clusterID,
+			options.ClusterName,
 			options.WorkingDir,
 			options.HostedCP,
 			options.HealthCheckTimeout,
@@ -489,9 +489,9 @@ func (r *Provider) waitForClusterToBeInstalled(ctx context.Context, clusterID, c
 }
 
 // waitForClusterToBeHealthy waits for the cluster health check job to succeed
-func (r *Provider) waitForClusterToBeHealthy(ctx context.Context, client *openshiftclient.Client, clusterID, reportDir string, hostedCP bool, timeout time.Duration) error {
+func (r *Provider) waitForClusterToBeHealthy(ctx context.Context, client *openshiftclient.Client, clusterName, reportDir string, hostedCP bool, timeout time.Duration) error {
 	if hostedCP {
-		cluster, err := r.findCluster(ctx, clusterID)
+		cluster, err := r.findCluster(ctx, clusterName)
 		if err != nil {
 			return fmt.Errorf("hosted control plane cluster pre health check tasks failed, unable to locate cluster: %v", err)
 		}


### PR DESCRIPTION
# What
The wait for cluster to be healthy method previously was passing in the cluster id to find the cluster in ocm. The find cluster method actually requires the cluster name. This PR passes in the cluster name over cluster id.