### PR TITLE
ROSA provider: adjust clean up operations based on cluster settings

### DIFF
--- a/pkg/openshift/rosa/operatorroles.go
+++ b/pkg/openshift/rosa/operatorroles.go
@@ -18,12 +18,17 @@ func (o *operatorRoleError) Error() string {
 }
 
 // deleteOIDCConfigProvider deletes the oidc config provider associated to the cluster
-func (r *Provider) deleteOperatorRoles(ctx context.Context, clusterID string) error {
+func (r *Provider) deleteOperatorRoles(ctx context.Context, clusterID, clusterPrefix, oidcConfigID string) error {
 	commandArgs := []string{
 		"delete", "operator-roles",
-		"--cluster", clusterID,
 		"--mode", "auto",
 		"--yes",
+	}
+
+	if oidcConfigID != "" {
+		commandArgs = append(commandArgs, "--prefix", clusterPrefix)
+	} else {
+		commandArgs = append(commandArgs, "--cluster", clusterID)
 	}
 
 	r.log.Info("Deleting cluster operator roles", clusterIDLoggerKey, clusterID, ocmEnvironmentLoggerKey, r.ocmEnvironment)


### PR DESCRIPTION
# What
This commit adjusts the ROSA delete cluster method to properly clean up a clusters operator roles and oidc provider. Resources were being left over due to there are different options that need to be provided when you use an oidc config id.

Reference: https://github.com/openshift/rosa/blob/master/cmd/dlt/cluster/cmd.go#L114-L124