### PR TITLE
SDCICD-1049: ROSA Provider Updates

### DIFF
--- a/examples/rosadeletecluster/rosadeletecluster.go
+++ b/examples/rosadeletecluster/rosadeletecluster.go
@@ -39,14 +39,21 @@ func main() {
 		_ = provider.Client.Close()
 	}()
 
+	deleteOptions := &rosa.DeleteClusterOptions{
+		ClusterName: clusterName,
+		ClusterID:   clusterID,
+		HostedCP:    hostedCP,
+		STS:         sts,
+	}
+
+	if hostedCP {
+		deleteOptions.DeleteHostedCPVPC = true
+		deleteOptions.DeleteOidcConfigID = true
+	}
+
 	err = provider.DeleteCluster(
 		ctx,
-		&rosa.DeleteClusterOptions{
-			ClusterName: clusterName,
-			ClusterID:   clusterID,
-			HostedCP:    hostedCP,
-			STS:         sts,
-		},
+		deleteOptions,
 	)
 	if err != nil {
 		log.Fatalf("Failed to delete rosa cluster: %v", err)

--- a/pkg/clients/ocm/credentials.go
+++ b/pkg/clients/ocm/credentials.go
@@ -16,8 +16,8 @@ func (c *Client) getKubeconfig(ctx context.Context, clusterID string) (string, e
 }
 
 // GetKubeconfig returns the clusters kubeconfig file
-func (c *Client) KubeconfigFile(ctx context.Context, clusterID string) (string, error) {
-	filename := fmt.Sprintf("%s-kubeconfig", clusterID)
+func (c *Client) KubeconfigFile(ctx context.Context, clusterID, directory string) (string, error) {
+	filename := fmt.Sprintf("%s/%s-kubeconfig", directory, clusterID)
 
 	kubeconfig, err := c.getKubeconfig(ctx, clusterID)
 	if err != nil {

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -16,13 +17,16 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/wait"
 )
 
+const defaultAccountRolesPrefix = "ManagedOpenShift"
+
 // CreateClusterOptions represents data used to create clusters
 type CreateClusterOptions struct {
-	FIPS            bool
-	HostedCP        bool
-	MultiAZ         bool
-	STS             bool
-	SkipHealthCheck bool
+	FIPS                         bool
+	HostedCP                     bool
+	MultiAZ                      bool
+	STS                          bool
+	SkipHealthCheck              bool
+	UseDefaultAccountRolesPrefix bool
 
 	HostPrefix int
 	Replicas   int
@@ -97,7 +101,12 @@ func (r *Provider) CreateCluster(ctx context.Context, options *CreateClusterOpti
 		}
 		majorMinor := fmt.Sprintf("%d.%d", version.Major(), version.Minor())
 
-		accountRoles, err := r.createAccountRoles(ctx, options.ClusterName, majorMinor, options.ChannelGroup)
+		accountRolesPrefix := options.ClusterName
+		if options.UseDefaultAccountRolesPrefix {
+			accountRolesPrefix = fmt.Sprintf("%s-%s", defaultAccountRolesPrefix, majorMinor)
+		}
+
+		accountRoles, err := r.createAccountRoles(ctx, accountRolesPrefix, majorMinor, options.ChannelGroup)
 		if err != nil {
 			return "", &clusterError{action: action, err: err}
 		}
@@ -228,9 +237,11 @@ func (r *Provider) DeleteCluster(ctx context.Context, options *DeleteClusterOpti
 	}
 
 	if options.STS {
-		err = r.deleteAccountRoles(ctx, options.ClusterName)
-		if err != nil {
-			return &clusterError{action: action, err: err}
+		if !strings.Contains(cluster.AWS().STS().RoleARN(), defaultAccountRolesPrefix) {
+			err = r.deleteAccountRoles(ctx, options.ClusterName)
+			if err != nil {
+				return &clusterError{action: action, err: err}
+			}
 		}
 	}
 

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -343,6 +343,9 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 	if options.HostedCP {
 		commandArgs = append(commandArgs, "--hosted-cp")
 		commandArgs = append(commandArgs, "--oidc-config-id", options.OidcConfigID)
+	}
+
+	if options.SubnetIDs != "" {
 		commandArgs = append(commandArgs, "--subnet-ids", options.SubnetIDs)
 	}
 
@@ -369,8 +372,6 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 	commandArgs = append(commandArgs, "--replicas", fmt.Sprint(options.Replicas))
 
 	if options.SubnetIDs != "" {
-		commandArgs = append(commandArgs, "--subnet-ids", options.SubnetIDs)
-
 		if options.HTTPProxy != "" {
 			commandArgs = append(commandArgs, "--http-proxy", options.HTTPProxy)
 		}

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -561,8 +561,6 @@ func (o *CreateClusterOptions) setHealthCheckTimeout(duration time.Duration) {
 // setDefaultDeleteClusterOptions sets default options when creating clusters
 func (o *DeleteClusterOptions) setDefaultDeleteClusterOptions() {
 	if o.HostedCP {
-		o.DeleteHostedCPVPC = true
-		o.DeleteOidcConfigID = true
 		o.STS = true
 	}
 

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -141,7 +141,7 @@ func (r *Provider) CreateCluster(ctx context.Context, options *CreateClusterOpti
 	}
 
 	if !options.SkipHealthCheck {
-		kubeconfigFile, err := r.Client.KubeconfigFile(ctx, clusterID)
+		kubeconfigFile, err := r.Client.KubeconfigFile(ctx, clusterID, os.TempDir())
 		if err != nil {
 			return clusterID, &clusterError{action: action, err: err}
 		}

--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -50,6 +50,7 @@ func (r *providerError) Error() string {
 // RunCommand runs the rosa command provided
 func (r *Provider) RunCommand(ctx context.Context, command *exec.Cmd) (io.Writer, io.Writer, error) {
 	command.Env = append(command.Environ(), r.awsCredentials.CredentialsAsList()...)
+	command.Env = append(command.Env, fmt.Sprintf("OCM_CONFIG=%s/ocm.json", os.TempDir()))
 	commandWithArgs := fmt.Sprintf("rosa%s", strings.Split(command.String(), "rosa")[1])
 	r.log.Info("Command", rosaCommandLoggerKey, commandWithArgs)
 	return cmd.Run(command)
@@ -181,6 +182,7 @@ func verifyLogin(ctx context.Context, rosaBinary string, token string, ocmEnviro
 
 	command := exec.CommandContext(ctx, rosaBinary, commandArgs...)
 	command.Env = append(command.Environ(), awsCredentials.CredentialsAsList()...)
+	command.Env = append(command.Env, fmt.Sprintf("OCM_CONFIG=%s/ocm.json", os.TempDir()))
 
 	_, _, err := cmd.Run(command)
 	if err != nil {

--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	downloadURL    = "https://mirror.openshift.com/pub/openshift-v4/clients/rosa"
-	minimumVersion = "1.2.22"
+	minimumVersion = "1.2.23"
 	tarFilename    = "rosa.tar.gz"
 )
 

--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -50,7 +50,8 @@ func (r *providerError) Error() string {
 // RunCommand runs the rosa command provided
 func (r *Provider) RunCommand(ctx context.Context, command *exec.Cmd) (io.Writer, io.Writer, error) {
 	command.Env = append(command.Environ(), r.awsCredentials.CredentialsAsList()...)
-	r.log.Info("Command", rosaCommandLoggerKey, strings.Split(command.String(), "bin/")[1])
+	commandWithArgs := fmt.Sprintf("rosa%s", strings.Split(command.String(), "rosa")[1])
+	r.log.Info("Command", rosaCommandLoggerKey, commandWithArgs)
 	return cmd.Run(command)
 }
 


### PR DESCRIPTION
# What
This PR aims to address minor tweaks to the ROSA provider to make it even more consumable to other go modules (e.g. osde2e) based on their needs. The changes made in this PR, does not impact the end result of the provider (to create a cluster or delete a cluster).

Changes included in this PR:
- Fix a bug found when logging the ROSA CLI command to run with its options
- Accept a new parameter to define where a clusters kubeconfig file should be written to
- Remove setting defaults for VPC/OIDC config deletion
- Set the minimum ROSA version to 1.2.23
- Set where ROSA login writes the `ocm.json` file to (defaults it to systems temporary directory)
- Remove setting subnet ids option twice
- Add a new create cluster options field to use the default account roles prefix (ManagedOpenShift) if the caller wishes to over creating unique ones per cluster

# Jira
- [SDCICD-1049](https://issues.redhat.com//browse/SDCICD-1049)