### PR TITLE
ROSA Provider: Miscellaneous Updates From Continued Testing

### DIFF
--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -56,6 +56,14 @@ func (r *Provider) RunCommand(ctx context.Context, command *exec.Cmd) (io.Writer
 	return cmd.Run(command)
 }
 
+// Uninstall removes the rosa cli that was downloaded to the systems temp directory
+func (r *Provider) Uninstall(ctx context.Context) error {
+	if strings.Contains(r.rosaBinary, os.TempDir()) {
+		return os.Remove(r.rosaBinary)
+	}
+	return nil
+}
+
 // cliExist checks if rosa cli is available else it will download it
 func cliCheck() (string, error) {
 	var (


### PR DESCRIPTION
# What
This PR includes the following changes to the provider:
- When a new ROSA provider is constructed, when checking the ROSA version meets the minimum version defined, it will log this. Providing a way for the caller program to know what exact version of ROSA was used.
- Add a new `Uninstall` method that takes care of removing the ROSA binary that may have been downloaded at runtime to the file systems temporary directory. It will not remove the ROSA binary if one was found (it was never downloaded to begin).
