### PR TITLE
pkg/openshift/rosa: set minimum version to 1.2.24

### DIFF
--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	downloadURL    = "https://mirror.openshift.com/pub/openshift-v4/clients/rosa"
-	minimumVersion = "1.2.23"
+	minimumVersion = "1.2.24"
 	tarFilename    = "rosa.tar.gz"
 )
 


### PR DESCRIPTION
This PR sets the minimum ROSA version from 1.2.23 to 1.2.24 now that it is available on the [public site](https://mirror.openshift.com/pub/openshift-v4/clients/rosa).