### PR TITLE
pkg/openshift/rosa: accept either cluster name or id when deleting

### DIFF
--- a/examples/rosadeletecluster/rosadeletecluster.go
+++ b/examples/rosadeletecluster/rosadeletecluster.go
@@ -16,7 +16,6 @@ func main() {
 		ctx = context.Background()
 
 		clusterName = "cluster-123"
-		clusterID   = "cluster-123-id"
 
 		hostedCP = false
 		sts      = true
@@ -41,7 +40,6 @@ func main() {
 
 	deleteOptions := &rosa.DeleteClusterOptions{
 		ClusterName: clusterName,
-		ClusterID:   clusterID,
 		HostedCP:    hostedCP,
 		STS:         sts,
 	}
@@ -59,5 +57,5 @@ func main() {
 		log.Fatalf("Failed to delete rosa cluster: %v", err)
 	}
 
-	logger.Info("Cluster deleted!", "clusterID", clusterID)
+	logger.Info("Cluster deleted!", "clusterName", clusterName)
 }

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -57,7 +57,6 @@ type CreateClusterOptions struct {
 
 // DeleteClusterOptions represents data used to delete clusters
 type DeleteClusterOptions struct {
-	ClusterID   string
 	ClusterName string
 	WorkingDir  string
 
@@ -217,7 +216,7 @@ func (r *Provider) DeleteCluster(ctx context.Context, options *DeleteClusterOpti
 		return &clusterError{action: action, err: err}
 	}
 
-	err = r.waitForClusterToBeDeleted(ctx, options.ClusterName, options.WorkingDir, options.UninstallTimeout)
+	err = r.waitForClusterToBeDeleted(ctx, cluster.Name(), options.WorkingDir, options.UninstallTimeout)
 	if err != nil {
 		return &clusterError{action: action, err: err}
 	}
@@ -245,7 +244,7 @@ func (r *Provider) DeleteCluster(ctx context.Context, options *DeleteClusterOpti
 		if options.DeleteHostedCPVPC {
 			err = r.deleteHostedControlPlaneVPC(
 				ctx,
-				options.ClusterName,
+				cluster.Name(),
 				r.awsCredentials.Region,
 				options.WorkingDir,
 			)
@@ -441,7 +440,7 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 
 // findCluster gets the cluster the body
 func (r *Provider) findCluster(ctx context.Context, clusterName string) (*clustersmgmtv1.Cluster, error) {
-	query := fmt.Sprintf("product.id = 'rosa' AND name = '%s'", clusterName)
+	query := fmt.Sprintf("product.id = 'rosa' AND (name = '%[1]s' OR id = '%[1]s')", clusterName)
 	response, err := r.ClustersMgmt().V1().Clusters().List().
 		Search(query).
 		Page(1).


### PR DESCRIPTION
# Change
This PR allows the ROSA `DeleteCluster` method to accept either the cluster name or id to be deleted. Previously it was looking for the cluster name.