### PR TITLE
pkg/openshift/rosa: increase hcp health check timeout to 20 minutes

### DIFF
--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -567,7 +567,7 @@ func (o *CreateClusterOptions) setDefaultCreateClusterOptions() {
 	if o.HostedCP {
 		o.STS = true
 		o.setInstallTimeout(30)
-		o.setHealthCheckTimeout(10)
+		o.setHealthCheckTimeout(20)
 	} else {
 		o.setInstallTimeout(120)
 		o.setHealthCheckTimeout(45)


### PR DESCRIPTION
# Change
More recently we have been seeing the health check timeouts failing "waiting for nodes to be ready". This commit will double the timeout to 20 minutes from 10 and can be re-tuned once we get a better new average of how long it takes.