### PR TITLE
pkg/openshift/rosa: download rosa tar file to tmp directory

### DIFF
--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -23,7 +23,6 @@ import (
 const (
 	downloadURL    = "https://mirror.openshift.com/pub/openshift-v4/clients/rosa"
 	minimumVersion = "1.2.24"
-	tarFilename    = "rosa.tar.gz"
 )
 
 // Provider is a rosa provider
@@ -67,12 +66,13 @@ func (r *Provider) Uninstall(ctx context.Context) error {
 // cliExist checks if rosa cli is available else it will download it
 func cliCheck() (string, error) {
 	var (
-		url          = fmt.Sprintf("%s/%s", downloadURL, minimumVersion)
-		rosaFilename = fmt.Sprintf("%s/rosa", os.TempDir())
+		url             = fmt.Sprintf("%s/%s", downloadURL, minimumVersion)
+		rosaFilename    = fmt.Sprintf("%s/rosa", os.TempDir())
+		rosaTarFilePath = fmt.Sprintf("%s/rosa.tar.gz", os.TempDir())
 	)
 
 	defer func() {
-		_ = os.Remove(tarFilename)
+		_ = os.Remove(rosaTarFilePath)
 	}()
 
 	runtimeOS := runtime.GOOS
@@ -96,9 +96,9 @@ func cliCheck() (string, error) {
 	}
 	defer response.Body.Close()
 
-	tarFile, err := os.Create(tarFilename)
+	tarFile, err := os.Create(rosaTarFilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to create %s tar file: %v", tarFilename, err)
+		return "", fmt.Errorf("failed to create %s tar file: %v", rosaTarFilePath, err)
 	}
 	defer tarFile.Close()
 
@@ -116,18 +116,18 @@ func cliCheck() (string, error) {
 
 	_, err = io.Copy(tarFile, response.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to write content to %s: %v", tarFilename, err)
+		return "", fmt.Errorf("failed to write content to %s: %v", rosaTarFilePath, err)
 	}
 
-	tarFileReader, err := os.Open(tarFilename)
+	tarFileReader, err := os.Open(rosaTarFilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to open %s: %v", tarFilename, err)
+		return "", fmt.Errorf("failed to open %s: %v", rosaTarFilePath, err)
 	}
 	defer tarFileReader.Close()
 
 	gzipReader, err := gzip.NewReader(tarFileReader)
 	if err != nil {
-		return "", fmt.Errorf("failed to create gzip reader for %s: %v", tarFilename, err)
+		return "", fmt.Errorf("failed to create gzip reader for %s: %v", rosaTarFilePath, err)
 	}
 	defer gzipReader.Close()
 


### PR DESCRIPTION
# Change
Previously the rosa tar file was being downloaded to the file path where the go file is run. This fails when running within a prow CI job. To workaround this, we can download the tar file to the tmp directory of the container. Similar to where the actual rosa binary cli gets installed to.

PR aims to resolve the error seen [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.12-rosa-hcp/1691862241223118848).

```
2023/08/16 17:22:48 e2e.go:293: OSDE2E failed: could not setup cluster provider: failed to construct rosa provider: failed to create rosa.tar.gz tar file: open rosa.tar.gz: permission denied
```