### PR TITLE
pkg/clients/openshift: ignore notfound err

### DIFF
--- a/pkg/clients/openshift/healthcheck.go
+++ b/pkg/clients/openshift/healthcheck.go
@@ -29,6 +29,9 @@ func (c *Client) OSDClusterHealthy(ctx context.Context, jobName, reportDir strin
 		if apierrors.IsNotFound(err) {
 			if err = wait.For(func() (bool, error) {
 				if err = c.Get(ctx, jobName, osdClusterReadyNamespace, &job); err != nil {
+					if apierrors.IsNotFound(err) {
+						return false, nil
+					}
 					return false, err
 				}
 				return true, nil


### PR DESCRIPTION
the osd-cluster-ready job is not available at the time of querying,
ensure that the error is not 'not found' while waiting for it to appear

Signed-off-by: Brady Pratt <bpratt@redhat.com>
