### PR TITLE
pkg/clients/openshift: set delete propagation for deleting query pod

### DIFF
--- a/pkg/clients/openshift/upgrade_operator.go
+++ b/pkg/clients/openshift/upgrade_operator.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 )
@@ -233,7 +234,7 @@ func (c *Client) getReplacesCSV(ctx context.Context, name, namespace, channel st
 	}
 
 	defer func() {
-		_ = c.Delete(ctx, job)
+		_ = c.Delete(ctx, job, resources.WithDeletePropagation("Background"))
 	}()
 
 	// TODO: this doesn't fail _when_ the job fails, it waits for it to be completed


### PR DESCRIPTION
the pods are getting left up otherwise:

```
"level"=0 "msg"="child pods are preserved by default when jobs are deleted; set propagationPolicy=Background to remove them or set propagationPolicy=Orphan to suppress this warning"
```

Signed-off-by: Brady Pratt <bpratt@redhat.com>
