### PR TITLE
Updates based on Rosa 1.2.26-rc1

### DIFF
--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -114,7 +114,7 @@ func (r *Provider) CreateCluster(ctx context.Context, options *CreateClusterOpti
 		return "", &clusterError{action: action, err: err}
 	}
 
-	if options.STS {
+	if options.HostedCP || options.STS {
 		version, err := semver.NewVersion(options.Version)
 		if err != nil {
 			return "", &clusterError{action: action, err: fmt.Errorf("failed to parse version into semantic version: %v", err)}
@@ -131,9 +131,7 @@ func (r *Provider) CreateCluster(ctx context.Context, options *CreateClusterOpti
 			return "", &clusterError{action: action, err: err}
 		}
 		options.accountRoles = *accountRoles
-	}
 
-	if options.HostedCP {
 		if options.OidcConfigID == "" {
 			options.OidcConfigID, err = r.createOIDCConfig(
 				ctx,
@@ -144,7 +142,9 @@ func (r *Provider) CreateCluster(ctx context.Context, options *CreateClusterOpti
 				return "", &clusterError{action: action, err: err}
 			}
 		}
+	}
 
+	if options.HostedCP {
 		if options.SubnetIDs == "" {
 			vpc, err := r.createHostedControlPlaneVPC(
 				ctx,
@@ -354,6 +354,7 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 		"--role-arn", options.accountRoles.installerRoleARN,
 		"--support-role-arn", options.accountRoles.supportRoleARN,
 		"--worker-iam-role", options.accountRoles.workerRoleARN,
+		"--oidc-config-id", options.OidcConfigID,
 		"--yes",
 	}
 

--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	downloadURL    = "https://mirror.openshift.com/pub/openshift-v4/clients/rosa"
-	minimumVersion = "1.2.24"
+	minimumVersion = "1.2.25"
 )
 
 // Provider is a rosa provider


### PR DESCRIPTION
Ref Thread:
https://redhat-internal.slack.com/archives/CMK13BP4J/p1692724384885839
https://issues.redhat.com/browse/SDCICD-1086

The purpose of this PR is to update the provider logic for the Rosa provider to match the new behavior found in Rosa 1.2.26+
1. The command: 'rosa create account-roles --mode auto' now creates the HCP account roles as well which ups the roles created to 7 instead of 4. 
2. It seems they are handling oidcconfigids a bit different as well. When trying to run the 'rosa create cluster ...options' without the '--oidc-config-id $id' the binary exits with an os.Exit(1). This seems like a bug as the log reads 'WARN: No OIDC Configuration found; will continue with the classic flow.' So to get by I'm swapping the oidcconfigid creation to happen for STS clusters as well. 

Tested locally I'm running into a problem with the AWS account that needs to be added for stage creation. 
Did not test the HCP flows with these changes. 

Signed-off-by: Diego Santamaria <dsantama@redhat.com>