### PR TITLE
clients/openshift: NewFromRestConfig

### DIFF
--- a/pkg/clients/openshift/client.go
+++ b/pkg/clients/openshift/client.go
@@ -28,6 +28,10 @@ func NewFromKubeconfig(filename string, logger logr.Logger) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get kubernetes config: %w", err)
 	}
+	return NewFromRestConfig(cfg, logger)
+}
+
+func NewFromRestConfig(cfg *rest.Config, logger logr.Logger) (*Client, error) {
 	client, err := resources.New(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to created dynamic client: %w", err)


### PR DESCRIPTION
allow creating a new openshift client from just the base restconfig object

see https://github.com/openshift/osde2e/pull/2151