### PR TITLE
clients/openshift: handle IsHttp2ConnectionLost error

### DIFF
--- a/pkg/clients/openshift/errors.go
+++ b/pkg/clients/openshift/errors.go
@@ -11,7 +11,7 @@ func isRetryableAPIError(err error) bool {
 	// These errors may indicate a transient error that we can retry in tests.
 	if apierrors.IsInternalError(err) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) ||
 		apierrors.IsTooManyRequests(err) || utilnet.IsProbableEOF(err) || utilnet.IsConnectionReset(err) ||
-		utilnet.IsConnectionRefused(err) {
+		utilnet.IsConnectionRefused(err) || utilnet.IsHTTP2ConnectionLost(err) {
 		return true
 	}
 


### PR DESCRIPTION
healthceck polling is failing locally for `http2: client connection lost` often. Add it to the list to retry

```
E1019 04:20:17.294344   24959 healthcheck.go:40]  "msg"="failed waiting for healthcheck job to finish" "error"="Get \"https://api.osde2e-sints.928m.s1.devshift.org:6443/apis/batch/v1/namespaces/openshift-monitoring/jobs/osd-cluster-ready\": http2: client connection lost"
```

https://github.com/openshift/kubernetes/blob/c0449761f4ad0c3a585990c26aea90a1dadb82cb/staging/src/k8s.io/apimachinery/pkg/util/net/util.go#L51C1-L54