### PR TITLE
Bump minimumVersion for Rosa CLI to 1.2.29

### DIFF
--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	downloadURL    = "https://mirror.openshift.com/pub/openshift-v4/clients/rosa"
-	minimumVersion = "1.2.27"
+	minimumVersion = "1.2.29"
 )
 
 // Provider is a rosa provider


### PR DESCRIPTION
Ref Error: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/45379/rehearse-45379-pull-ci-openshift-osde2e-main-hypershift-pr-check/1721835111948750848

```
2023/11/07 10:26:08 events.go:27: Fail event: InstallFailed
2023/11/07 10:26:08 e2e.go:87: Failed to set up or retrieve cluster: could not launch cluster: create cluster failed: error: failed to wait for command to finish: exit status 1, stderr: ERR: Failed to create cluster: Creating hosted control plane cluster requires ROSA 1.2.29 or higher. Go to https://console.redhat.com/openshift/downloads#tool-rosa to download the latest version.
```