### PR TITLE
openshift/rosa: bump min version to 1.2.30

### DIFF
--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	downloadURL    = "https://mirror.openshift.com/pub/openshift-v4/clients/rosa"
-	minimumVersion = "1.2.29"
+	minimumVersion = "1.2.30"
 )
 
 // Provider is a rosa provider


### PR DESCRIPTION
failing to create hcp clusters with current version, bump to latest

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/45379/rehearse-45379-pull-ci-openshift-osde2e-main-hypershift-pr-check/1724789996373676032