### PR TITLE
matcher for olm.owner label

### DIFF
--- a/pkg/gomega/matchers/contain_item_with_prefix.go
+++ b/pkg/gomega/matchers/contain_item_with_prefix.go
@@ -35,3 +35,32 @@ func ContainItemWithPrefix(prefix string) types.GomegaMatcher {
 		return false, nil
 	})
 }
+
+// ContainItemWithOLMOwnerWithPrefix is a gomega matcher that can be used to assert that a
+// Kubernetes list object contains an item olm.owner label with the provided prefix.
+// This matcher is preferred in case of operator related objects when object name itself
+// does not contain desired prefix, but has olm.owner label which contains it.
+//
+//	var rolebindings rbacv1.RoleBindingList
+//	err = k8s.List(ctx, &rolebindings)
+//	Expect(err).ShouldNot(HaveOccurred(), "failed to list rolebindings")
+//	Expect(&roleBindingsList).Should(ContainItemWithOLMOwnerWithPrefix("test"))
+func ContainItemWithOLMOwnerWithPrefix(prefix string) types.GomegaMatcher {
+	return gcustom.MakeMatcher(func(list k8s.ObjectList) (bool, error) {
+		items, err := meta.ExtractList(list)
+		if err != nil {
+			return false, fmt.Errorf("not a list type: %w", err)
+		}
+		for _, item := range items {
+			accessor, err := meta.Accessor(item)
+			if err != nil {
+				return false, fmt.Errorf("unable to get item's objectmeta: %w", err)
+			}
+			labels := accessor.GetLabels()
+			if strings.HasPrefix(labels["olm.owner"], prefix) {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}

--- a/pkg/gomega/matchers/contain_item_with_prefix_test.go
+++ b/pkg/gomega/matchers/contain_item_with_prefix_test.go
@@ -12,18 +12,20 @@ var _ = Describe("list", func() {
 	It("should contain the item", func() {
 		list := &rbacv1.RoleList{
 			Items: []rbacv1.Role{
-				{ObjectMeta: metav1.ObjectMeta{Name: "test123"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "test123", Labels: map[string]string{"olm.owner": "abc123"}}},
 			},
 		}
 		Expect(list).Should(ContainItemWithPrefix("test"))
+		Expect(list).Should(ContainItemWithOLMOwnerWithPrefix("abc"))
 	})
 
 	It("should not contain the item", func() {
 		list := &appsv1.DeploymentList{
 			Items: []appsv1.Deployment{
-				{ObjectMeta: metav1.ObjectMeta{Name: "brady"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "brady", Labels: map[string]string{"olm.owner": "ritu"}}},
 			},
 		}
 		Expect(list).ShouldNot(ContainItemWithPrefix("test"))
+		Expect(list).ShouldNot(ContainItemWithOLMOwnerWithPrefix("test"))
 	})
 })


### PR DESCRIPTION
Starting 4.15, "name" value on clusterrole, clusterrolebinding objects for an operator are getting truncated to fit olm requirements

These objects contain a label "olm.owner" if they belong to the same operator which isn't truncated.

Adding a matcher to use for these assertions on operator tests. 
