### PR TITLE
pkg/openshift/rosa: stop parsing version

### DIFF
--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -13,7 +13,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/openshift/osde2e-common/internal/cmd"
@@ -172,12 +171,7 @@ func getVersion(ctx context.Context, rosaBinary string) (string, error) {
 		return "", errors.New("getVersion failed to get version from cli standard out")
 	}
 
-	currentVersion, err := semver.NewVersion(strings.ReplaceAll(versionSlice[0], "\n", ""))
-	if err != nil {
-		return "", fmt.Errorf("getVersion failed to parse version to semantic version: %v", err)
-	}
-
-	return currentVersion.String(), nil
+	return strings.ReplaceAll(versionSlice[0], "\n", ""), nil
 }
 
 // verifyLogin validates the authentication details provided are valid by logging in with rosa cli


### PR DESCRIPTION
rosa version now includes some junk related to the build that is not
semver compatible. Just return the full thing since we no longer gate
logic based on the version.

```
❯ ./rosa version
1.2.35 (Build: )
I: Your ROSA CLI is up to date.
```

https://redhat-internal.slack.com/archives/CMK13BP4J/p1708967421818679

Signed-off-by: Brady Pratt <bpratt@redhat.com>
