### PR TITLE
pkg/openshift/rosa: use provided duration directly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/api v0.28.2
 	k8s.io/apimachinery v0.28.2
 	k8s.io/client-go v0.28.2
+	k8s.io/klog/v2 v2.100.1
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
 	sigs.k8s.io/e2e-framework v0.3.0
 )
@@ -78,7 +79,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
 	sigs.k8s.io/controller-runtime v0.15.1 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -117,7 +117,7 @@ func (r *Provider) CreateCluster(ctx context.Context, options *CreateClusterOpti
 	if options.HostedCP || options.STS {
 		version, err := semver.NewVersion(options.Version)
 		if err != nil {
-			return "", &clusterError{action: action, err: fmt.Errorf("failed to parse version into semantic version: %v", err)}
+			return "", &clusterError{action: action, err: fmt.Errorf("failed to parse version (%q) into semantic version: %v", options.Version, err)}
 		}
 		majorMinor := fmt.Sprintf("%d.%d", version.Major(), version.Minor())
 
@@ -433,7 +433,7 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 	}
 
 	if options.ExpirationDuration > 0 {
-		commandArgs = append(commandArgs, "--expiration-time", time.Now().Add(options.ExpirationDuration*time.Minute).UTC().Format(time.RFC3339))
+		commandArgs = append(commandArgs, "--expiration-time", time.Now().Add(options.ExpirationDuration).UTC().Format(time.RFC3339))
 	}
 
 	r.log.Info("Initiating cluster creation", clusterNameLoggerKey, options.ClusterName, ocmEnvironmentLoggerKey, r.ocmEnvironment)


### PR DESCRIPTION
the value of ExpirationDuration should be respected directly and not
mutated to produce a higher value

`opts.ExpirationDuration = 8 * time.Hour`

Signed-off-by: Brady Pratt <bpratt@redhat.com>
