### PR TITLE
misc: add .ci-operator.yml config

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: golang-1.21


### PR DESCRIPTION
this allows for easier bumping of go versions within the repo