### PR TITLE
Fixing additional-trust-bundle-file flag usage

### DIFF
--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -428,7 +428,7 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 		}
 
 		if options.AdditionalTrustBundleFile != "" {
-			commandArgs = append(commandArgs, "----additional-trust-bundle-file", options.AdditionalTrustBundleFile)
+			commandArgs = append(commandArgs, "--additional-trust-bundle-file", options.AdditionalTrustBundleFile)
 		}
 	}
 


### PR DESCRIPTION
Fixing `--additional-trust-bundle-file` flag for `rosa create cluster` command for byo-vpc-proxy-install setup. 

Error:
```shell
Failed to execute root command: bad flag syntax: ----additional-trust-bundle-file
```

Reference job - https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-rosa-stage-e2e-byo-vpc-proxy-install/1795530782698115072 