### PR TITLE
misc: group k8s dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     - "dependencies"
     - "ok-to-test"
   open-pull-requests-limit: 20
+  groups:
+    kubernetes:
+      patterns:
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"


### PR DESCRIPTION
group them together so they stay in sync and can be bumped easier