### PR TITLE
Remove whoami check from verifylogin

### DIFF
--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -202,11 +202,6 @@ func verifyLogin(ctx context.Context, rosaBinary string, token string, clientID 
 		return fmt.Errorf("login failed with %q: %w", stderr, err)
 	}
 
-	_, stderr, err = cmd.Run(exec.CommandContext(ctx, rosaBinary, "whoami"))
-	if err != nil {
-		return fmt.Errorf("whoami failed with %q: %w", stderr, err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Have to remove this whoami check. 

When I tested locally I didn't realize that I already have an OCM session locally. 
This flow breaks on a fresh session. 

ERR: Failed to create OCM connection: either a token, an user name and password or a client identifier and secret are necessary, but none has been provided