### PR TITLE
openshift/rosa: support additional parameters

### DIFF
--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -28,9 +28,13 @@ type CreateClusterOptions struct {
 	MintMode                     bool
 	SkipHealthCheck              bool
 	UseDefaultAccountRolesPrefix bool
+	EnableAutoscaling            bool
+	ETCDEncryption               bool
 
-	HostPrefix int
-	Replicas   int
+	HostPrefix  int
+	Replicas    int
+	MinReplicas int
+	MaxReplicas int
 
 	ArtifactDir               string
 	AdditionalTrustBundleFile string
@@ -422,7 +426,25 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 		}
 	}
 
-	commandArgs = append(commandArgs, "--replicas", fmt.Sprint(options.Replicas))
+	if options.EnableAutoscaling {
+		commandArgs = append(commandArgs, "--enable-autoscaling")
+	}
+
+	if options.ETCDEncryption {
+		commandArgs = append(commandArgs, "--etcd-encryption")
+	}
+
+	if options.MinReplicas > 0 {
+		commandArgs = append(commandArgs, "--min-replicas", fmt.Sprint(options.MinReplicas))
+	}
+
+	if options.MaxReplicas > 0 {
+		commandArgs = append(commandArgs, "--max-replicas", fmt.Sprint(options.MaxReplicas))
+	}
+
+	if options.MinReplicas == 0 && options.MaxReplicas == 0 {
+		commandArgs = append(commandArgs, "--replicas", fmt.Sprint(options.Replicas))
+	}
 
 	if options.SubnetIDs != "" {
 		if options.HTTPProxy != "" {


### PR DESCRIPTION
the SDN migration effort needs additional flags for cluster provisioning:

```
--enable-autoscaling
--min-replicas
--max-replicas
--etcd-encryption
```

when min/max-replicas is set, replicas cannot be

output:

```
"level"=0 "msg"="Command" "rosa_command"="rosa create cluster --output json --cluster-name creed-sdn-ovn-1 --channel-group stable --compute-machine-type m5.xlarge --machine-cidr 10.0.0.0/16 --region us-east-1 --version 4.14.14 --host-prefix 0 --oidc-config-id 2crf9hdst7t9vt9n7rpbvtremfai722s --yes --role-arn arn:aws:iam::3696:role/ManagedOpenShift-4.14-Installer-Role --controlplane-iam-role arn:aws:iam::696:role/ManagedOpenShift-4.14-ControlPlane-Role --support-role-arn arn:aws:iam::3696:role/ManagedOpenShift-4.14-Support-Role --worker-iam-role arn:aws:iam::96:role/ManagedOpenShift-4.14-Worker-Role --mode auto --sts --network-type OpenShiftSDN --multi-az --enable-autoscaling --etcd-encryption --min-replicas 3 --max-replicas 24"
  "level"=0 "msg"="Cluster creation initiated!" "cluster_name"="creed-sdn-ovn-1" "cluster_id"="2crfatsabcg7kel272pend4ava90t594" "ocm_environment"="https://api.stage.openshift.com"
"level"=0 "msg"="Waiting for cluster to be installed" "cluster_id"="2crfatsabcg7keva90t594" "cluster_name"="creed-sdn-ovn-1" "timeout"="2h0m0s" "ocm_environment"="https://api.stage.openshift.com"
```