### PR TITLE
[WIP] Enables the --debug flag for rosa commands.

### DIFF
--- a/examples/rosaCreatePrivateLinkCluster/rosaCreatePrivateLinkCluster.go
+++ b/examples/rosaCreatePrivateLinkCluster/rosaCreatePrivateLinkCluster.go
@@ -41,6 +41,7 @@ func main() {
 		os.Getenv("OCM_TOKEN"),
 		os.Getenv("OCM_CLIENT_ID"),
 		os.Getenv("OCM_CLIENT_SECRET"),
+		os.Getenv("DEBUG"),
 		ocmclient.FedRampIntegration,
 		logger,
 		&awscloud.AWSCredentials{Profile: "", Region: ""},

--- a/examples/rosacreatecluster/rosacreatecluster.go
+++ b/examples/rosacreatecluster/rosacreatecluster.go
@@ -30,6 +30,7 @@ func main() {
 		os.Getenv("OCM_TOKEN"),
 		os.Getenv("OCM_CLIENT_ID"),
 		os.Getenv("OCM_CLIENT_SECRET"),
+		os.Getenv("DEBUG"),
 		ocmclient.Stage,
 		logger,
 		&awscloud.AWSCredentials{Profile: "", Region: ""},

--- a/examples/rosadeletecluster/rosadeletecluster.go
+++ b/examples/rosadeletecluster/rosadeletecluster.go
@@ -28,6 +28,7 @@ func main() {
 		os.Getenv("OCM_TOKEN"),
 		os.Getenv("OCM_CLIENT_ID"),
 		os.Getenv("OCM_CLIENT_SECRET"),
+		os.Getenv("DEBUG"),
 		ocmclient.Stage,
 		logger,
 		&awscloud.AWSCredentials{Profile: "", Region: ""},


### PR DESCRIPTION
This actually won't work due to our version logic. 
We take a json and convert it to a map here: 
https://github.com/openshift/osde2e-common/blob/main/pkg/openshift/rosa/versions.go#L62

When added with the --debug flag it throws off the Unmarshal step. 