### PR TITLE
Set default for DeleteHostedCPVPC for hosted plane.

### DIFF
--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -657,6 +657,7 @@ func (o *CreateClusterOptions) setHealthCheckTimeout(duration time.Duration) {
 func (o *DeleteClusterOptions) setDefaultDeleteClusterOptions() {
 	if o.HostedCP {
 		o.STS = true
+		o.DeleteHostedVPC = true
 	}
 
 	if o.ArtifactDir == "" {


### PR DESCRIPTION
A vpc is created for hosted planes in each cluster creation by default. Therefore they should be set to be deleted at the end.