### PR TITLE
SDCICD-1351 Update the client logins to use client credentials.

### DIFF
--- a/pkg/clients/ocm/client.go
+++ b/pkg/clients/ocm/client.go
@@ -3,6 +3,7 @@ package ocm
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	ocmsdk "github.com/openshift-online/ocm-sdk-go"
 )
@@ -31,11 +32,11 @@ func New(ctx context.Context,
 ) (*Client, error) {
 	connectionBuilder := ocmsdk.NewConnectionBuilder().URL(string(environment))
 
-	if clientID != "" && clientSecret != "" {
+	if strings.Contains(string(environment), "fr") {
 		connectionBuilder.Client(clientID, clientSecret).
 			TokenURL(fedrampTokenURL)
 	} else {
-		connectionBuilder.Tokens(token)
+		connectionBuilder.Client(clientID, clientSecret)
 	}
 
 	connection, err := connectionBuilder.BuildContext(ctx)

--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -50,10 +50,6 @@ func (r *providerError) Error() string {
 // RunCommand runs the rosa command provided
 func (r *Provider) RunCommand(ctx context.Context, command *exec.Cmd) (io.Writer, io.Writer, error) {
 	command.Env = append(command.Environ(), r.awsCredentials.CredentialsAsList()...)
-	// If r.ocmEnvironment is not fedramp, then set the OCM_CONFIG environment variable
-	if !r.fedRamp {
-		command.Env = append(command.Env, fmt.Sprintf("OCM_CONFIG=%s/ocm.json", os.TempDir()))
-	}
 	commandWithArgs := fmt.Sprintf("rosa%s", strings.Split(command.String(), "rosa")[1])
 	r.log.Info("Command", rosaCommandLoggerKey, commandWithArgs)
 	return cmd.Run(command)
@@ -189,10 +185,10 @@ func verifyLogin(ctx context.Context, rosaBinary string, token string, clientID 
 	if clientID != "" && clientSecret != "" {
 		command.Args = append(command.Args, "--client-id", clientID)
 		command.Args = append(command.Args, "--client-secret", clientSecret)
-		command.Args = append(command.Args, "--govcloud")
 		// TODO: Work around. The rosa cli for govcloud does not support the --env passing the api endpoint.
 		// The environment selection can be handled with a data structure that maps the environment to the api endpoint.
 		if ocmEnvironment == "https://api.int.openshiftusgov.com" {
+			command.Args = append(command.Args, "--govcloud")
 			ocmEnvironment = "integration"
 		}
 	} else {


### PR DESCRIPTION
This update enables the client and clientsecrets to be used for login in commercial and not just fedramp. 