### PR TITLE
Update the OCM_CONFIG variable to work with client credentials.

### DIFF
--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -191,10 +191,16 @@ func verifyLogin(ctx context.Context, rosaBinary string, token string, clientID 
 			command.Args = append(command.Args, "--govcloud")
 			ocmEnvironment = "integration"
 		}
-	} else {
+	} else if token != "" {
 		command.Args = append(command.Args, "--token", token)
-		command.Env = append(command.Env, fmt.Sprintf("OCM_CONFIG=%s/ocm.json", os.TempDir()))
+	} else {
+		return fmt.Errorf("no authentication details provided")
 	}
+	/*
+		The OCM_CONFIG variable is part of the ocm-cli functionality, for more information this is the description ocm-cli repo.
+		https://github.com/openshift-online/ocm-cli?tab=readme-ov-file#multiple-concurrent-logins-with-ocm_config
+	*/
+	command.Env = append(command.Env, fmt.Sprintf("OCM_CONFIG=%s/ocm.json", os.TempDir()))
 	command.Args = append(command.Args, "--env", string(ocmEnvironment))
 	command.Args = append(command.Args, "--region", string(awsCredentials.Region))
 


### PR DESCRIPTION
https://github.com/openshift-online/ocm-cli?tab=readme-ov-file#multiple-concurrent-logins-with-ocm_config
https://issues.redhat.com/browse/SDE-4270

This PR fixes an issue I encountered when introducing log in through the client credentials. The env var OCM_CONFIG is used from the OCM cli to store login information and needs to be set to the os.TempDir() which will allow the OSDe2e docker image all required permissions in the local file system. 