### PR TITLE
Re-add the connectionbuilder for the OCM client using offline token. 

### DIFF
--- a/pkg/clients/ocm/client.go
+++ b/pkg/clients/ocm/client.go
@@ -17,6 +17,7 @@ const (
 	FedRampProduction  Environment = "https://api.openshiftusgov.com"
 	FedRampStage       Environment = "https://api.stage.openshiftusgov.com"
 	FedRampIntegration Environment = "https://api.int.openshiftusgov.com"
+	tokenURL           string      = "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
 	fedrampTokenURL    string      = "https://sso.int.openshiftusgov.com/realms/redhat-external/protocol/openid-connect/token"
 )
 
@@ -35,6 +36,8 @@ func New(ctx context.Context,
 	if strings.Contains(string(environment), "fr") {
 		connectionBuilder.Client(clientID, clientSecret).
 			TokenURL(fedrampTokenURL)
+	} else if token != "" {
+		connectionBuilder.TokenURL(tokenURL).Client("cloud-services", "").Tokens(token)
 	} else {
 		connectionBuilder.Client(clientID, clientSecret)
 	}


### PR DESCRIPTION
This change will allow pipelines to use the offline token while the operator focus test are rebuilt. 