### PR TITLE
Fix: add exception for nil pointer panic

### DIFF
--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -507,11 +507,13 @@ func (r *Provider) findCluster(ctx context.Context, clusterName string) (*cluste
 		Page(1).
 		Size(1).
 		SendContext(ctx)
-
-	if response.Total() == 1 {
-		return response.Items().Slice()[0], nil
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving cluster %q from ocm %q: %v", clusterName, r.ocmEnvironment, err)
 	}
-	return nil, fmt.Errorf("cluster %q not found in ocm %q: %v", clusterName, r.ocmEnvironment, err)
+	if response == nil || response.Items().Len() == 0 {
+		return nil, fmt.Errorf("empty response for cluster %q from ocm %q", clusterName, r.ocmEnvironment)
+	}
+	return response.Items().Slice()[0], nil
 }
 
 // deleteCluster handles sending the request to delete the cluster


### PR DESCRIPTION
We came across panic. It seems that `response.Total()==1` check is not sufficient to ensure response items are not empty. 

`panic({0x33ce740?, 0xc00129e000?})
		/usr/lib/golang/src/runtime/panic.go:785 +0x132
	github.com/openshift/osde2e-common/pkg/openshift/rosa.(*Provider).findCluster(0xc000ebec60, {0x3ce84e8, 0xc00126c070}, {0xc001043c04, 0xc})
		/go/pkg/mod/github.com/openshift/osde2e-common@v0.0.0-20250425180409-b9162e21257f/pkg/openshift/rosa/cluster.go:512 +0x425`