### PR TITLE
pkg/openshift/rosa: default BillingAccountID

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os/exec"
 )
 
 // Run executes the os.exec command provided
-func Run(command *exec.Cmd) (io.Writer, io.Writer, error) {
+func Run(command *exec.Cmd) (bytes.Buffer, bytes.Buffer, error) {
 	var stdout, stderr bytes.Buffer
 
 	// TODO: Configure tee output to file and buffer
@@ -18,21 +17,21 @@ func Run(command *exec.Cmd) (io.Writer, io.Writer, error) {
 
 	err := command.Start()
 	if err != nil {
-		return command.Stdout, command.Stderr, fmt.Errorf("failed to start command: %v", err)
+		return stdout, stderr, fmt.Errorf("failed to start command: %v", err)
 	}
 
 	err = command.Wait()
 	if err != nil {
-		return command.Stdout, command.Stderr, fmt.Errorf("failed to wait for command to finish: %v", err)
+		return stdout, stderr, fmt.Errorf("failed to wait for command to finish: %v", err)
 	}
 
-	return command.Stdout, command.Stderr, nil
+	return stdout, stderr, nil
 }
 
 // ConvertOutputToMap converts a json string formatted to a map object
-func ConvertOutputToMap(data io.Writer) (map[string]any, error) {
+func ConvertOutputToMap(data bytes.Buffer) (map[string]any, error) {
 	var result map[string]any
-	err := json.Unmarshal([]byte(fmt.Sprint(data)), &result)
+	err := json.Unmarshal(data.Bytes(), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -40,9 +39,9 @@ func ConvertOutputToMap(data io.Writer) (map[string]any, error) {
 }
 
 // ConvertOutputToListOfMaps converts a list of json string formatted to a list of map objects
-func ConvertOutputToListOfMaps(data io.Writer) ([]map[string]any, error) {
+func ConvertOutputToListOfMaps(data bytes.Buffer) ([]map[string]any, error) {
 	var result []map[string]any
-	err := json.Unmarshal([]byte(fmt.Sprint(data)), &result)
+	err := json.Unmarshal(data.Bytes(), &result)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -63,7 +63,7 @@ type CreateClusterOptions struct {
 	HealthCheckTimeout time.Duration
 	ExpirationDuration time.Duration
 
-	BillingAccountID string 
+	BillingAccountID string
 }
 
 // DeleteClusterOptions represents data used to delete clusters
@@ -407,8 +407,8 @@ func (r *Provider) createCluster(ctx context.Context, options *CreateClusterOpti
 		commandArgs = append(commandArgs, "--mode", "auto")
 	}
 
-	if options.HostedCP && options.BillingAccountID == "" {
-		return "", errors.New("billing account ID is required for hosted control plane clusters")
+	if options.BillingAccountID == "" {
+		options.BillingAccountID = r.user.AWSAccountID
 	}
 
 	if options.HostedCP {

--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -2,6 +2,7 @@ package rosa
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"errors"
@@ -48,7 +49,7 @@ func (r *providerError) Error() string {
 }
 
 // RunCommand runs the rosa command provided
-func (r *Provider) RunCommand(ctx context.Context, command *exec.Cmd) (io.Writer, io.Writer, error) {
+func (r *Provider) RunCommand(ctx context.Context, command *exec.Cmd) (bytes.Buffer, bytes.Buffer, error) {
 	command.Env = append(command.Environ(), r.awsCredentials.CredentialsAsList()...)
 	commandWithArgs := fmt.Sprintf("rosa%s", strings.Split(command.String(), "rosa")[1])
 	r.log.Info("Command", rosaCommandLoggerKey, commandWithArgs)

--- a/pkg/openshift/rosa/rosa.go
+++ b/pkg/openshift/rosa/rosa.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -25,6 +26,12 @@ const (
 	downloadURL = "https://mirror.openshift.com/pub/openshift-v4/clients/rosa"
 )
 
+// accountInfo represents the rosa whoami command response
+type accountInfo struct {
+	AWSAccountID     string `json:"AWS Account ID"`
+	AWSDefaultRegion string `json:"AWS Default Region"`
+}
+
 // Provider is a rosa provider
 type Provider struct {
 	*ocmclient.Client
@@ -34,6 +41,7 @@ type Provider struct {
 
 	AWSRegion  string
 	rosaBinary string
+	user       *accountInfo
 
 	fedRamp bool
 }
@@ -54,6 +62,23 @@ func (r *Provider) RunCommand(ctx context.Context, command *exec.Cmd) (bytes.Buf
 	commandWithArgs := fmt.Sprintf("rosa%s", strings.Split(command.String(), "rosa")[1])
 	r.log.Info("Command", rosaCommandLoggerKey, commandWithArgs)
 	return cmd.Run(command)
+}
+
+// whoami runs 'rosa whoami -o json' and parses the response
+func (r *Provider) whoami(ctx context.Context) (*accountInfo, error) {
+	commandArgs := []string{"whoami", "-o", "json"}
+
+	stdout, stderr, err := r.RunCommand(ctx, exec.CommandContext(ctx, r.rosaBinary, commandArgs...))
+	if err != nil {
+		return nil, fmt.Errorf("failed to run rosa whoami: %v, stderr: %s", err, stderr.String())
+	}
+
+	acctInfo := &accountInfo{}
+	if err := json.Unmarshal(stdout.Bytes(), acctInfo); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal whoami output: %v", err)
+	}
+
+	return acctInfo, nil
 }
 
 // Uninstall removes the rosa cli that was downloaded to the systems temp directory
@@ -277,6 +302,13 @@ func New(ctx context.Context, token string, clientID string, clientSecret string
 		Client:         nil,
 		log:            logger,
 	}
+
+	// Get user information via rosa whoami
+	acctInfo, err := provider.whoami(ctx)
+	if err != nil {
+		return nil, &providerError{err: fmt.Errorf("failed to get user information: %v", err)}
+	}
+	provider.user = acctInfo
 
 	if awsCredentials.Region == "random" {
 		// Set a temporary region to select a random region later on


### PR DESCRIPTION
```
commit 6b62b290b04870da04c69e4bbf8d3f76304ef748
Author: Brady Pratt <bpratt@redhat.com>
Date:   Thu Jul 10 06:53:17 2025 -0500

    pkg/openshift/rosa: run rosa whoami on creation

    fetch the contents of `rosa whoami` on new provider so we have access to
    things like account id and default region (unused).

    We can then set the `BillingAccountID` to the account we are running
    under

    Signed-off-by: Brady Pratt <bpratt@redhat.com>

commit 0d27e13bb6f03776583dae7419cc1c94a5782bba
Author: Brady Pratt <bpratt@redhat.com>
Date:   Thu Jul 10 02:02:31 2025 -0500

    internal/cmd: return bytes.Buffer

    return a struct and not an interface following the Go idiom of `Accept
    interfaces, return structs`. This allows us to operate on the type
    directly as what it is and will always be (a bytes.Buffer)

    Signed-off-by: Brady Pratt <bpratt@redhat.com>
```