### PR TITLE
Improve osd-cluster-ready health check logging

### DIFF
--- a/pkg/clients/openshift/healthcheck.go
+++ b/pkg/clients/openshift/healthcheck.go
@@ -36,6 +36,9 @@ func (c *Client) OSDClusterHealthy(ctx context.Context, reportDir string, timeou
 				return true, nil
 			}
 		}
+		c.log.Info(fmt.Sprintf("job %s/%s not yet complete: active=%d succeeded=%d failed=%d",
+			osdClusterReadyNamespace, osdClusterReadyName,
+			job.Status.Active, job.Status.Succeeded, job.Status.Failed))
 		return false, nil
 	}, wait.WithTimeout(timeout)); err != nil {
 		c.log.Error(err, "failed waiting for healthcheck job to finish")
@@ -43,6 +46,8 @@ func (c *Client) OSDClusterHealthy(ctx context.Context, reportDir string, timeou
 		if err != nil {
 			return fmt.Errorf("unable to get job logs for %s/%s: %w", osdClusterReadyNamespace, osdClusterReadyName, err)
 		}
+		c.log.Info(fmt.Sprintf("=== %s/%s job logs ===\n%s\n=== end job logs ===",
+			osdClusterReadyNamespace, osdClusterReadyName, logs))
 		jobLogsFile := fmt.Sprintf("%s/%s.log", reportDir, osdClusterReadyName)
 		if err = os.WriteFile(jobLogsFile, []byte(logs), os.FileMode(0o644)); err != nil {
 			return fmt.Errorf("failed to write job %s logs to file: %w", osdClusterReadyName, err)


### PR DESCRIPTION
## Summary

- Log the osd-cluster-ready job status (active/succeeded/failed counts) on every poll iteration, instead of silently retrying when the job exists but hasn't completed
- Print the osd-cluster-ready job pod logs to stdout on health check timeout, before writing them to the artifact file

## Context

While investigating [osde2e nightly failures](https://storage.googleapis.com/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws/2043763140423847936/build-log.txt) across 4.19-4.22, we found that the health check poll loop was completely silent after the initial error log. The osd-cluster-ready job existed on the cluster but was crash-looping because a dependent operator (splunk-forwarder-operator) had an RBAC issue. The only visible output in the Prow build log was a single `"failed to get job"` message followed by ~2 hours of silence until the timeout.

These changes make it possible to diagnose health check failures directly from CI output without needing to download separate artifact files or access the cluster.

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` passes with 0 issues
- [x] `gofumpt` produces no additional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging during OpenShift cluster health status verification, including additional diagnostic information when operations are in progress and detailed logs when timeouts or failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->