### PR TITLE
SDCICD-1752 Early provisioning error 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+version: 2
+
+linters-settings:
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
+
+run:
+  timeout: 3m
+  skip-dirs:
+    - vendor
+
+issues:
+  exclude-dirs:
+    - vendor

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ gofumpt:
 	gofumpt -w .
 
 lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v2.7.2
 	golangci-lint run --timeout 3m0s ./...

--- a/pkg/openshift/rosa/cluster.go
+++ b/pkg/openshift/rosa/cluster.go
@@ -611,6 +611,7 @@ func (r *Provider) waitForClusterToBeInstalled(ctx context.Context, clusterID, c
 			return "", fmt.Errorf("failed to convert output to map: %v", err)
 		}
 
+		// TODO: Safely extract cluster state with type checking
 		clusterState := fmt.Sprint(output["status"].(map[string]any)["state"])
 
 		return clusterState, err
@@ -622,6 +623,11 @@ func (r *Provider) waitForClusterToBeInstalled(ctx context.Context, clusterID, c
 		clusterState, err := getClusterState()
 		if err != nil {
 			return false, err
+		}
+
+		// Fail fast on terminal error states
+		if clusterState == "error" || clusterState == "failed" || clusterState == "uninstalling" {
+			return false, fmt.Errorf("cluster entered terminal state: %s", clusterState)
 		}
 
 		if clusterState != "ready" {


### PR DESCRIPTION
Early return on errored cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster installation by detecting terminal error states immediately, providing faster feedback when installation fails instead of waiting for timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->