### PR TITLE
Replace osd-cluster-ready Job wait with ClusterOperator health check

### DIFF
--- a/pkg/clients/openshift/client.go
+++ b/pkg/clients/openshift/client.go
@@ -91,6 +91,9 @@ func (c *Client) GetJobLogs(ctx context.Context, name, namespace string) (string
 	if err != nil {
 		return "", fmt.Errorf("failed to list pods for job %s in %s namespace: %w", name, namespace, err)
 	}
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("no pods found for job %s in %s namespace", name, namespace)
+	}
 	// TODO: there may be a case where the first item isn't correct
 	return c.GetPodLogs(ctx, pods.Items[0].GetName(), namespace)
 }

--- a/pkg/clients/openshift/healthcheck.go
+++ b/pkg/clients/openshift/healthcheck.go
@@ -6,58 +6,82 @@ import (
 	"os"
 	"time"
 
-	batchv1 "k8s.io/api/batch/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 )
 
 const (
-	osdClusterReadyName      = "osd-cluster-ready"
-	osdClusterReadyNamespace = "openshift-monitoring"
-	jobNameLoggerKey         = "job_name"
-	timeoutLoggerKey         = "timeout"
+	timeoutLoggerKey = "timeout"
 )
 
 // OSDClusterHealthy waits for the cluster to be in a healthy "ready" state
-// by confirming the osd-ready-job finishes successfully
+// by confirming every ClusterOperator is Available, not Degraded, and not
+// Progressing.
+//
+// This previously waited on the osd-cluster-ready Job, but that Job was
+// removed cluster-side (see openshift/managed-cluster-config#ROSAENG-1342):
+// it duplicated the ClusterOperator Progressing=false signal checked here,
+// and nothing in OCM/OSDFM consumed its completion signal. Waiting on a Job
+// that no longer exists caused this check to time out on every cluster, and
+// the subsequent GetJobLogs call to panic when no pods were ever created for
+// it.
 func (c *Client) OSDClusterHealthy(ctx context.Context, reportDir string, timeout time.Duration) error {
-	if err := wait.For(func(ctx context.Context) (bool, error) {
-		job := new(batchv1.Job)
-		if err := c.Get(ctx, osdClusterReadyName, osdClusterReadyNamespace, job); err != nil {
-			c.log.Error(err, fmt.Sprintf("failed to get job %s/%s", osdClusterReadyNamespace, osdClusterReadyName))
-			if IsRetryableAPIError(err) || apierrors.IsNotFound(err) {
+	c.log.Info("Waiting for cluster operators to report healthy", timeoutLoggerKey, timeout.Round(time.Second).String())
+
+	var unhealthy []string
+	err := wait.For(func(ctx context.Context) (bool, error) {
+		operators := new(configv1.ClusterOperatorList)
+		if err := c.List(ctx, operators); err != nil {
+			if IsRetryableAPIError(err) {
+				c.log.Error(err, "failed to list cluster operators, retrying")
 				return false, nil
 			}
 			return false, err
 		}
-		for _, cond := range job.Status.Conditions {
-			if cond.Type == batchv1.JobComplete && cond.Status == corev1.ConditionTrue {
-				return true, nil
+
+		if len(operators.Items) == 0 {
+			return false, nil
+		}
+
+		unhealthy = unhealthy[:0]
+		for _, operator := range operators.Items {
+			if !clusterOperatorHealthy(operator) {
+				unhealthy = append(unhealthy, operator.Name)
 			}
 		}
-		c.log.Info(fmt.Sprintf("job %s/%s not yet complete: active=%d succeeded=%d failed=%d",
-			osdClusterReadyNamespace, osdClusterReadyName,
-			job.Status.Active, job.Status.Succeeded, job.Status.Failed))
-		return false, nil
-	}, wait.WithTimeout(timeout)); err != nil {
-		c.log.Error(err, "failed waiting for healthcheck job to finish")
-		logs, err := c.GetJobLogs(ctx, osdClusterReadyName, osdClusterReadyNamespace)
-		if err != nil {
-			return fmt.Errorf("unable to get job logs for %s/%s: %w", osdClusterReadyNamespace, osdClusterReadyName, err)
+
+		if len(unhealthy) > 0 {
+			c.log.Info(fmt.Sprintf("waiting for %d cluster operator(s) to become healthy", len(unhealthy)), "unhealthy_operators", unhealthy)
+			return false, nil
 		}
-		c.log.Info(fmt.Sprintf("=== %s/%s job logs ===\n%s\n=== end job logs ===",
-			osdClusterReadyNamespace, osdClusterReadyName, logs))
-		jobLogsFile := fmt.Sprintf("%s/%s.log", reportDir, osdClusterReadyName)
-		if err = os.WriteFile(jobLogsFile, []byte(logs), os.FileMode(0o644)); err != nil {
-			return fmt.Errorf("failed to write job %s logs to file: %w", osdClusterReadyName, err)
-		}
-		return fmt.Errorf("%s/%s failed to complete (check %s for more info): %w", osdClusterReadyNamespace, osdClusterReadyName, jobLogsFile, err)
+
+		return true, nil
+	}, wait.WithTimeout(timeout))
+	if err != nil {
+		return fmt.Errorf("cluster operators failed to report healthy within %s (last unhealthy: %v): %w", timeout, unhealthy, err)
 	}
 
-	c.log.Info("Cluster job finished successfully!", jobNameLoggerKey, osdClusterReadyName)
+	c.log.Info("Cluster operators reported healthy!")
 
 	return nil
+}
+
+// clusterOperatorHealthy returns true if the operator is Available, not
+// Degraded, and not Progressing.
+func clusterOperatorHealthy(operator configv1.ClusterOperator) bool {
+	var available, degraded, progressing bool
+	for _, condition := range operator.Status.Conditions {
+		switch condition.Type {
+		case configv1.OperatorAvailable:
+			available = condition.Status == configv1.ConditionTrue
+		case configv1.OperatorDegraded:
+			degraded = condition.Status == configv1.ConditionTrue
+		case configv1.OperatorProgressing:
+			progressing = condition.Status == configv1.ConditionTrue
+		}
+	}
+	return available && !degraded && !progressing
 }
 
 // HCPClusterHealthy waits for the cluster to be in a health "ready" state


### PR DESCRIPTION
The osd-cluster-ready Job and its RBAC were removed cluster-side by openshift/managed-cluster-config@3265bc3f7b ([ROSAENG-1342](https://redhat.atlassian.net/browse/ROSAENG-1342)): it duplicated the ClusterOperator Progressing=false signal, and nothing in OCM/OSDFM consumed its completion signal. Since that Job no longer exists on any OSD/ROSA/HCP cluster, OSDClusterHealthy always timed out waiting for it, and the subsequent GetJobLogs call panicked with an index-out-of-range when it found zero pods for a Job that was never created.

- OSDClusterHealthy now polls ClusterOperators directly and waits for every operator to be Available, not Degraded, and not Progressing, matching what the removed Job actually validated.
- GetJobLogs now returns an error instead of panicking when a Job has no pods, since that's a real, reachable case (e.g. a Job that was never scheduled, not just one whose pods were garbage collected).

[ROSAENG-1342]: https://redhat.atlassian.net/browse/ROSAENG-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster health checks by confirming all cluster operators are available and stable.
  * Added clearer timeout reporting for operators that remain unhealthy.
  * Added an explicit error when job logs cannot be retrieved because no matching pods exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->